### PR TITLE
Add GitHub Copilot support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,15 +29,15 @@ Specify supports multiple AI agents by generating agent-specific command files a
 
 ### Current Supported Agents
 
-| Agent | Directory | Format | CLI Tool | Description |
-|-------|-----------|---------|----------|-------------|
-| **Claude Code** | `.claude/commands/` | Markdown | `claude` | Anthropic's Claude Code CLI |
-| **Gemini CLI** | `.gemini/commands/` | TOML | `gemini` | Google's Gemini CLI |
-| **GitHub Copilot** | `.github/prompts/` | Markdown | N/A (IDE-based) | GitHub Copilot in VS Code |
-| **Cursor** | `.cursor/commands/` | Markdown | `cursor-agent` | Cursor CLI |
-| **Qwen Code** | `.qwen/commands/` | TOML | `qwen` | Alibaba's Qwen Code CLI |
-| **opencode** | `.opencode/command/` | Markdown | `opencode` | opencode CLI |
-| **Windsurf** | `.windsurf/workflows/` | Markdown | N/A (IDE-based) | Windsurf IDE workflows |
+| Agent | Directory | Format | CLI Tool | Context File | Description |
+|-------|-----------|---------|----------|--------------|-------------|
+| **Claude Code** | `.claude/commands/` | Markdown | `claude` | `CLAUDE.md` | Anthropic's Claude Code CLI |
+| **Gemini CLI** | `.gemini/commands/` | TOML | `gemini` | `GEMINI.md` | Google's Gemini CLI |
+| **GitHub Copilot** | N/A (IDE-based) | N/A | N/A (IDE-based) | `.github/copilot-instructions.md` | GitHub Copilot in VS Code |
+| **Cursor** | `.cursor/commands/` | Markdown | `cursor-agent` | `.cursor/rules/specify-rules.mdc` | Cursor CLI |
+| **Qwen Code** | `.qwen/commands/` | TOML | `qwen` | `QWEN.md` | Alibaba's Qwen Code CLI |
+| **opencode** | `.opencode/command/` | Markdown | `opencode` | `AGENTS.md` | opencode CLI |
+| **Windsurf** | `.windsurf/workflows/` | Markdown | N/A (IDE-based) | `.windsurf/rules/specify-rules.md` | Windsurf IDE workflows |
 
 ### Step-by-Step Integration Guide
 
@@ -191,11 +191,16 @@ Command content with {SCRIPT} and {{args}} placeholders.
 
 ## Directory Conventions
 
-- **CLI agents**: Usually `.<agent-name>/commands/`
+- **CLI agents**: Usually `.<agent-name>/commands/` for commands
 - **IDE agents**: Follow IDE-specific patterns:
-  - Copilot: `.github/prompts/`
-  - Cursor: `.cursor/commands/`
-  - Windsurf: `.windsurf/workflows/`
+  - Cursor: `.cursor/commands/` for commands, `.cursor/rules/specify-rules.mdc` for context
+  - Windsurf: `.windsurf/workflows/` for commands, `.windsurf/rules/specify-rules.md` for context
+- **Context files**: Agent-specific instruction files that provide project context:
+  - Claude: `CLAUDE.md`
+  - Gemini: `GEMINI.md`  
+  - Copilot: `.github/copilot-instructions.md`
+  - Qwen: `QWEN.md`
+  - opencode: `AGENTS.md`
 
 ## Argument Patterns
 

--- a/agent_templates/copilot/copilot-instructions.md
+++ b/agent_templates/copilot/copilot-instructions.md
@@ -1,0 +1,29 @@
+# [PROJECT NAME] Development Guidelines for GitHub Copilot
+
+Auto-generated from all feature plans. Last updated: [DATE]
+
+## Active Technologies
+[EXTRACTED FROM ALL PLAN.MD FILES]
+
+## Project Structure
+```
+[ACTUAL STRUCTURE FROM PLANS]
+```
+
+## Commands
+[ONLY COMMANDS FOR ACTIVE TECHNOLOGIES]
+
+## Code Style
+[LANGUAGE-SPECIFIC, ONLY FOR LANGUAGES IN USE]
+
+## Recent Changes
+[LAST 3 FEATURES AND WHAT THEY ADDED]
+
+## GitHub Copilot Specifics
+- This file serves as context for GitHub Copilot in VS Code
+- Use inline comments to guide code generation
+- Use descriptive variable and function names
+- Leverage autocomplete suggestions for boilerplate code
+
+<!-- MANUAL ADDITIONS START -->
+<!-- MANUAL ADDITIONS END -->


### PR DESCRIPTION
## Feature: GitHub Copilot Support

### Overview
Add comprehensive GitHub Copilot support with proper template files and enhanced documentation for multi-agent workflows.

### Changes
- Added GitHub Copilot template file (`agent_templates/copilot/copilot-instructions.md`)
- Enhanced agent documentation with GitHub Copilot integration
- Updated documentation for multi-AI assistant support

### Benefits
- Better GitHub Copilot integration with spec-kit
- Improved multi-agent workflow support
- Enhanced documentation for AI assistant usage

Fixes #422